### PR TITLE
Add a "block" for Gtfo warnings

### DIFF
--- a/DBM-Raids-Vanilla/Blocks/Gtfo.lua
+++ b/DBM-Raids-Vanilla/Blocks/Gtfo.lua
@@ -1,0 +1,64 @@
+-- TODO: This should be moved to core, but the dependency on core is a bit annoying while this is in a mostly experimental state
+
+-- A bit hacky, but works since the dev build requirement for tests was removed.
+---@class DBMCoreNamespace
+local private = DBM.Test:GetPrivate()
+
+---@class DBM
+local DBM = private:GetPrototype("DBM")
+
+---@class DBMMod
+local bossMod = private:GetPrototype("DBMMod")
+
+---@alias DBMBlockEventFilter fun(spellId: integer, spellName: string, srcGuid: string, dstGuid: string): boolean
+
+---@class GtfoBlockConfig
+---@field spell number|string: Main spell ID used for option and events
+---@field spellAura number|string|false?: Override spell ID for SPELL_AURA_APPLIED
+---@field spellDamage number|string|false?: Override spell ID for SPELL_DAMAGE/MISSED
+---@field spellPeriodicDamage number|string|false?: Override spell ID for SPELL_PERIOD_DAMAGE/MISSED
+---@field voice string|false?: Voice pack to play, default: "watchfeet"
+---@field specWarn SpecAnnounce1str?: Special warning, defaults to a GTFO special warning
+---@field antiSpam number?: AntiSpam delay, default: 2.5
+---@field antiSpamId string|number?: ID to share AntiSpam across warnings, default: "gtfo"
+---@field filter DBMBlockEventFilter?: Function that can return false to filter out a warning
+
+---@param config GtfoBlockConfig
+function bossMod:NewGtfo(config)
+	local optionSpellId = type(config.spell) == "string" and tonumber(config.spell:match("(%d+)")) or config.spell
+	local specWarn = config.specWarn or self.mergedGtfoWarning or self:NewSpecialWarningGTFO(optionSpellId, nil, nil, nil, 1, 8)
+	self.mergedGtfoWarning = specWarn
+	local function show(spellId, spellName, srcGuid, destGuid)
+		if config.filter and not config.filter(spellName, spellId, srcGuid, destGuid) then
+			return
+		end
+		if self:AntiSpam(config.antiSpam or 2.5, "gtfo") then
+			specWarn:Show(spellName)
+			if config.voice ~= false then
+				specWarn:Play(config.voice or "watchfeet")
+			end
+		end
+	end
+	local playerGuid = UnitGUID("player")
+	local function rawHandler(_, sourceGUID, _, _, _, destGUID, _, _, _, spellId, spellName)
+		if destGUID == playerGuid then
+			show(spellId, spellName, sourceGUID, destGUID)
+		end
+	end
+	local function handler(_, args)
+		if args:IsPlayer() then
+			show(args.spellId, args.spellName, args.sourceGUID, args.destGUID)
+		end
+	end
+	if config.spellAura ~= false then
+		self:RegisterEvent("SPELL_AURA_APPLIED", config.spellAura or config.spell, handler)
+	end
+	if config.spellPeriodicDamage ~= false then
+		self:RegisterRawEvent("SPELL_PERIODIC_DAMAGE", config.spellPeriodicDamage or config.spellDamage or config.spell, rawHandler)
+		self:RegisterRawEvent("SPELL_PERIODIC_MISSED", config.spellPeriodicDamage or config.spellDamage or config.spell, rawHandler)
+	end
+	if config.spellDamage ~= false then
+		self:RegisterRawEvent("SPELL_DAMAGE", config.spellDamage or config.spell, rawHandler)
+		self:RegisterRawEvent("SPELL_MISSED", config.spellDamage or config.spell, rawHandler)
+	end
+end

--- a/DBM-Raids-Vanilla/DBM-Raids-Vanilla_Cata.toc
+++ b/DBM-Raids-Vanilla/DBM-Raids-Vanilla_Cata.toc
@@ -41,6 +41,9 @@ localization.kr.lua
 localization.mx.lua
 localization.ru.lua
 
+# Temporary, will be moved to Core
+Blocks\Gtfo.lua
+
 AQ40\AQ40Trash.lua
 AQ40\Skeram.lua
 AQ40\ThreeBugs.lua

--- a/DBM-Raids-Vanilla/DBM-Raids-Vanilla_Mainline.toc
+++ b/DBM-Raids-Vanilla/DBM-Raids-Vanilla_Mainline.toc
@@ -45,6 +45,9 @@ localization.kr.lua
 localization.mx.lua
 localization.ru.lua
 
+# Temporary, will be moved to Core
+Blocks\Gtfo.lua
+
 AQ40\AQ40Trash.lua
 AQ40\Skeram.lua
 AQ40\ThreeBugs.lua

--- a/DBM-Raids-Vanilla/DBM-Raids-Vanilla_TBC.toc
+++ b/DBM-Raids-Vanilla/DBM-Raids-Vanilla_TBC.toc
@@ -41,6 +41,9 @@ localization.kr.lua
 localization.mx.lua
 localization.ru.lua
 
+# Temporary, will be moved to Core
+Blocks\Gtfo.lua
+
 VanillaNaxx\ArachnidQuarter\Anub'Rekhan.lua
 VanillaNaxx\ArachnidQuarter\Faerlina.lua
 VanillaNaxx\ArachnidQuarter\Maexxna.lua

--- a/DBM-Raids-Vanilla/DBM-Raids-Vanilla_Vanilla.toc
+++ b/DBM-Raids-Vanilla/DBM-Raids-Vanilla_Vanilla.toc
@@ -45,6 +45,9 @@ localization.kr.lua
 localization.mx.lua
 localization.ru.lua
 
+# Temporary, will be moved to Core
+Blocks\Gtfo.lua
+
 VanillaNaxx\ArachnidQuarter\Anub'Rekhan.lua
 VanillaNaxx\ArachnidQuarter\Faerlina.lua
 VanillaNaxx\ArachnidQuarter\Maexxna.lua

--- a/DBM-Raids-Vanilla/DBM-Raids-Vanilla_Wrath.toc
+++ b/DBM-Raids-Vanilla/DBM-Raids-Vanilla_Wrath.toc
@@ -41,6 +41,9 @@ localization.kr.lua
 localization.mx.lua
 localization.ru.lua
 
+# Temporary, will be moved to Core
+Blocks\Gtfo.lua
+
 AQ40\AQ40Trash.lua
 AQ40\Skeram.lua
 AQ40\ThreeBugs.lua

--- a/DBM-Raids-Vanilla/MC/Geddon.lua
+++ b/DBM-Raids-Vanilla/MC/Geddon.lua
@@ -28,9 +28,7 @@ end
 mod:RegisterCombat("combat")
 
 mod:RegisterEventsInCombat(
-	"SPELL_AURA_APPLIED 20475 19659 461090 461105 462402 465725 461103",
-	"SPELL_PERIODIC_DAMAGE 461103",
-	"SPELL_PERIODIC_MISSED 461103",
+	"SPELL_AURA_APPLIED 20475 19659 461090 461105 462402 465725",
 	"SPELL_AURA_REMOVED 20475 461090 461105 462402 465725",
 	"SPELL_CAST_SUCCESS 19695 19659 20478 20475 461090 461105 462402 461110 461121 465725"
 )
@@ -49,7 +47,6 @@ local yellBomb			= mod:NewYell(20475)
 local yellBombFades		= mod:NewShortFadesYell(20475)
 local specWarnInferno	= mod:NewSpecialWarningRun(19695, "Melee", nil, nil, 4, 2)
 local specWarnIgnite	= mod:NewSpecialWarningDispel(19659, "RemoveMagic", nil, nil, 1, 2)
-local specWarnGTFO		= mod:NewSpecialWarningGTFO(19698, nil, nil, nil, 1, 8)
 
 local timerInfernoCD	= mod:NewCDTimer(21, 19695, nil, nil, nil, 2)--21-27.9 (24-30 on sod?)
 local timerInferno		= mod:NewBuffActiveTimer(8, 19695, nil, nil, nil, 2)
@@ -60,24 +57,32 @@ local timerArmageddon	= mod:NewCastTimer(8, 20478, nil, nil, nil, 2, nil, nil, n
 
 mod:AddSetIconOption("SetIconOnBombTarget", 20475, false, 0, {8, 7, 6}) -- up to 3 bombs on heat level 3 (TODO: confirm)
 
-local specWarnGTFO2
+local function shouldShowInfernoGtfo()
+	if mod:IsTank() then
+		return false
+	end
+	return mod:IsEvent() or not mod:IsTrivial()
+end
+
+-- Inferno
+mod:NewGtfo{
+	spell = "19698 461088",
+	spellAura = "364838 461111",
+	spellPeriodicDamage = false,
+	filter = shouldShowInfernoGtfo
+}
+
+-- Bomb residue in SoD
 if DBM:IsSeasonal("SeasonOfDiscovery") then
-	specWarnGTFO2		= mod:NewSpecialWarningGTFO(461103, nil, nil, nil, 1, 8)
+	mod:NewGtfo{
+		spell = 461103,
+		spellDamage = false,
+	}
 end
 
 function mod:OnCombatStart(delay)
 	--timerIgniteManaCD:Start(7-delay)--7-19, too much variation for first
 	timerBombCD:Start(11-delay)
-	if not self:IsTank() and (self:IsEvent() or not self:IsTrivial()) then--Only want to warn if it's a threat
-		self:RegisterShortTermEvents(
-			"SPELL_DAMAGE 19698",
-			"SPELL_MISSED 19698"
-		)
-	end
-end
-
-function mod:OnCombatEnd()
-	self:UnregisterShortTermEvents()
 end
 
 local bombIcon = 8
@@ -101,19 +106,8 @@ function mod:SPELL_AURA_APPLIED(args)
 	elseif args:IsSpell(19659) and self:CheckDispelFilter("magic") then
 		specWarnIgnite:CombinedShow(0.3, args.destName)
 		specWarnIgnite:ScheduleVoice(0.3, "helpdispel")
-	elseif args:IsSpell(461103) and args:IsPlayer() and self:AntiSpam(3, "gtfo") and specWarnGTFO then
-		specWarnGTFO2:Show(args.spellName)
-		specWarnGTFO2:Play("watchfeet")
 	end
 end
-
-function mod:SPELL_PERIODIC_DAMAGE(_, _, _, _, destGUID, _, _, _, spellId, spellName)
-	if spellId == 461103 and destGUID == UnitGUID("player") and self:AntiSpam(3, "gtfo") and specWarnGTFO then
-		specWarnGTFO:Show(spellName)
-		specWarnGTFO:Play("watchfeet")
-	end
-end
-mod.SPELL_PERIODIC_MISSED = mod.SPELL_PERIODIC_DAMAGE
 
 function mod:SPELL_AURA_REMOVED(args)
 	if args:IsSpell(20475, 461090, 461105, 462402, 465725) then
@@ -146,15 +140,4 @@ function mod:SPELL_CAST_SUCCESS(args)
 		bombIcon = 8
 		timerBombCD:Start()
 	end
-end
-
-do
-	local Inferno = DBM:GetSpellName(19695)--Classic Note
-	function mod:SPELL_DAMAGE(_, _, _, _, destGUID, destName, _, _, spellId, spellName)
-		if (spellId == 19698 or spellName == Inferno) and destGUID == UnitGUID("player") and self:AntiSpam(2, 1) then
-			specWarnGTFO:Show(spellName)
-			specWarnGTFO:Play("watchfeet")
-		end
-	end
-	mod.SPELL_MISSED = mod.SPELL_DAMAGE
 end

--- a/DBM-Test-Vanilla/Season of Discovery/Molten Core/Reports/Geddon-Heat2-Kill.lua
+++ b/DBM-Test-Vanilla/Season of Discovery/Molten Core/Reports/Geddon-Heat2-Kill.lua
@@ -4,6 +4,7 @@ Mod:  DBM-Raids-Vanilla/Geddon
 
 Findings:
 	Unused event registration: SPELL_AURA_APPLIED 20475 (Living Bomb)
+	Unused event registration: SPELL_AURA_APPLIED 364838 (Inferno)
 	Unused event registration: SPELL_AURA_APPLIED 461105 (Living Bomb)
 	Unused event registration: SPELL_AURA_APPLIED 462402 (Living Bomb)
 	Unused event registration: SPELL_AURA_APPLIED 465725 (Living Bomb)
@@ -19,7 +20,9 @@ Findings:
 	Unused event registration: SPELL_CAST_SUCCESS 462402 (Living Bomb)
 	Unused event registration: SPELL_CAST_SUCCESS 465725 (Living Bomb)
 	Unused event registration: SPELL_DAMAGE 19698 (Inferno)
+	Unused event registration: SPELL_DAMAGE 461088 (Inferno)
 	Unused event registration: SPELL_MISSED 19698 (Inferno)
+	Unused event registration: SPELL_MISSED 461088 (Inferno)
 	Unused event registration: SPELL_PERIODIC_DAMAGE 461103 (Living Fallout)
 	Unused event registration: SPELL_PERIODIC_MISSED 461103 (Living Fallout)
 	SpecialWarning for spell ID 19695 (Inferno) is triggered by event SPELL_CAST_SUCCESS 461110 (Inferno)
@@ -33,7 +36,6 @@ Findings:
 
 Unused objects:
 	[Announce] Inferno, type=spell, spellId=19695
-	[Special Warning] %s damage - move away, type=gtfo, spellId=19698
 
 Timers:
 	Ignite Mana, time=27.00, type=cd, spellId=19659, triggerDeltas = 23.64, 30.24, 42.02, 30.34, 31.20
@@ -89,6 +91,11 @@ Announces:
 		[183.43] Scheduled at 183.33 by SPELL_AURA_APPLIED: [Baron Geddon->Healer2: Living Bomb] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, Player-1-00000009, Healer2, 0x512, 461090, Living Bomb, 0, DEBUFF, 0
 
 Special warnings:
+	%s damage - move away, type=gtfo, spellId=<none>, triggerDeltas = 42.12, 16.92, 16.23, 51.12, 25.59, 3.05
+		[ 42.12] SPELL_AURA_APPLIED: [->Dps5: Living Fallout] "", nil, 0x0, Player-1-00000005, Dps5, 0x511, 461103, Living Fallout, 0, DEBUFF, 0
+			 Triggered 2x, delta times: 42.12, 16.92
+		[ 75.27] SPELL_AURA_APPLIED: [->Dps5: Inferno] "", nil, 0x0, Player-1-00000005, Dps5, 0x511, 461111, Inferno, 0, DEBUFF, 0
+			 Triggered 4x, delta times: 75.27, 51.12, 25.59, 3.05
 	Ignite Mana on >%s< - dispel now, type=dispel, spellId=19659, triggerDeltas = 23.96, 30.23, 42.01, 30.36, 31.18
 		[ 23.96] Scheduled at 23.66 by SPELL_AURA_APPLIED: [Baron Geddon->Pet1: Ignite Mana] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, Pet-0-1-409-1-213450-0000000001, Pet1, 0x1112, 19659, Ignite Mana, 0, DEBUFF, 0
 		[ 54.19] Scheduled at 53.89 by SPELL_AURA_APPLIED: [Baron Geddon->Dps16: Ignite Mana] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, Player-1-00000020, Dps16, 0x512, 19659, Ignite Mana, 0, DEBUFF, 0
@@ -102,9 +109,6 @@ Special warnings:
 		[ 82.99] SPELL_AURA_APPLIED: [Baron Geddon->Dps5: Living Bomb] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, Player-1-00000005, Dps5, 0x511, 461090, Living Bomb, 0, DEBUFF, 0
 	Armageddon!, type=spell, spellId=20478, triggerDeltas = 191.38
 		[191.38] SPELL_CAST_SUCCESS: [Baron Geddon: Armageddon] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, "", nil, 0x0, 461121, Armageddon, 0, 0
-	%s damage - move away, type=gtfo, spellId=461103, triggerDeltas = 42.12, 16.92
-		[ 42.12] SPELL_AURA_APPLIED: [->Dps5: Living Fallout] "", nil, 0x0, Player-1-00000005, Dps5, 0x511, 461103, Living Fallout, 0, DEBUFF, 0
-			 Triggered 2x, delta times: 42.12, 16.92
 
 Yells:
 	%d, type=shortfade, spellId=20475
@@ -128,6 +132,8 @@ Voice pack sounds:
 	VoicePack/watchfeet
 		[ 42.12] SPELL_AURA_APPLIED: [->Dps5: Living Fallout] "", nil, 0x0, Player-1-00000005, Dps5, 0x511, 461103, Living Fallout, 0, DEBUFF, 0
 			 Triggered 2x, delta times: 42.12, 16.92
+		[ 75.27] SPELL_AURA_APPLIED: [->Dps5: Inferno] "", nil, 0x0, Player-1-00000005, Dps5, 0x511, 461111, Inferno, 0, DEBUFF, 0
+			 Triggered 4x, delta times: 75.27, 51.12, 25.59, 3.05
 
 Icons:
 	None
@@ -135,10 +141,8 @@ Icons:
 Event trace:
 	[  0.00] ENCOUNTER_START: 668, Baron Geddon, 226, 20, 0
 		StartCombat: ENCOUNTER_START
-		RegisterEvents: Regular, SPELL_AURA_APPLIED 20475 19659 461090 461105 462402 465725 461103, SPELL_PERIODIC_DAMAGE 461103, SPELL_PERIODIC_MISSED 461103, SPELL_AURA_REMOVED 20475 461090 461105 462402 465725, SPELL_CAST_SUCCESS 19695 19659 20478 20475 461090 461105 462402 461110 461121 465725
+		RegisterEvents: Regular, SPELL_AURA_APPLIED 20475 19659 461090 461105 462402 465725 364838 461111 461103, SPELL_AURA_REMOVED 20475 461090 461105 462402 465725, SPELL_CAST_SUCCESS 19695 19659 20478 20475 461090 461105 462402 461110 461121 465725, SPELL_DAMAGE 19698 461088, SPELL_MISSED 19698 461088, SPELL_PERIODIC_DAMAGE 461103, SPELL_PERIODIC_MISSED 461103
 		StartTimer: 11.0, Living Bomb
-		RegisterEvents: ShortTerm, SPELL_DAMAGE 19698, SPELL_MISSED 19698
-		RegisterEvents: Regular, SPELL_DAMAGE 19698, SPELL_MISSED 19698
 	[ 13.00] SPELL_CAST_SUCCESS: [Baron Geddon: Inferno] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, "", nil, 0x0, 461110, Inferno, 0, 0
 		ShowSpecialWarning: Inferno - run away
 		PlaySound: VoicePack/aesoon
@@ -264,6 +268,10 @@ Event trace:
 		PlaySound: VoicePack/aesoon
 		StartTimer: 8.0, Inferno ends
 		StartTimer: 21.0, Inferno
+	[ 75.27] SPELL_AURA_APPLIED: [->Dps5: Inferno] "", nil, 0x0, Player-1-00000005, Dps5, 0x511, 461111, Inferno, 0, DEBUFF, 0
+		AntiSpam: gtfo
+		ShowSpecialWarning: Inferno damage - move away
+		PlaySound: VoicePack/watchfeet
 	[ 82.97] SPELL_CAST_SUCCESS: [Baron Geddon: Living Bomb] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, "", nil, 0x0, 461090, Living Bomb, 0, 0
 		StartTimer: 13.3, Living Bomb
 	[ 82.99] SPELL_AURA_APPLIED: [Baron Geddon->Dps1: Living Bomb] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, Player-1-00000001, Dps1, 0x512, 461090, Living Bomb, 0, DEBUFF, 0
@@ -385,6 +393,10 @@ Event trace:
 		UnscheduleTask: specWarn19659dispel:ScheduleVoice("helpdispel") scheduled by ScheduleTask at 126.26
 		ScheduleTask: specWarn19659dispel:ScheduleVoice("helpdispel") at 126.56 (+0.30)
 			PlaySound: VoicePack/helpdispel
+	[126.39] SPELL_AURA_APPLIED: [->Dps5: Inferno] "", nil, 0x0, Player-1-00000005, Dps5, 0x511, 461111, Inferno, 0, DEBUFF, 0
+		AntiSpam: gtfo
+		ShowSpecialWarning: Inferno damage - move away
+		PlaySound: VoicePack/watchfeet
 	[141.22] SPELL_CAST_SUCCESS: [Baron Geddon: Living Bomb] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, "", nil, 0x0, 461090, Living Bomb, 0, 0
 		StartTimer: 13.3, Living Bomb
 	[141.22] SPELL_AURA_APPLIED: [Baron Geddon->Dps13: Living Bomb] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, Player-1-00000017, Dps13, 0x512, 461090, Living Bomb, 0, DEBUFF, 0
@@ -398,6 +410,10 @@ Event trace:
 		PlaySound: VoicePack/aesoon
 		StartTimer: 8.0, Inferno ends
 		StartTimer: 21.0, Inferno
+	[151.98] SPELL_AURA_APPLIED: [->Dps5: Inferno] "", nil, 0x0, Player-1-00000005, Dps5, 0x511, 461111, Inferno, 0, DEBUFF, 0
+		AntiSpam: gtfo
+		ShowSpecialWarning: Inferno damage - move away
+		PlaySound: VoicePack/watchfeet
 	[153.80] SPELL_CAST_SUCCESS: [Baron Geddon: Living Bomb] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, "", nil, 0x0, 461090, Living Bomb, 0, 0
 		StartTimer: 13.3, Living Bomb
 	[153.80] SPELL_AURA_APPLIED: [Baron Geddon->Dps9: Living Bomb] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, Player-1-00000012, Dps9, 0x512, 461090, Living Bomb, 0, DEBUFF, 0
@@ -406,6 +422,10 @@ Event trace:
 		StartTimer: 8.0, Living Bomb: Dps12
 		ScheduleTask: announce20475target:CombinedShow("Dps12") at 153.90 (+0.10)
 			ShowAnnounce: Living Bomb on Dps9, Dps12
+	[155.03] SPELL_AURA_APPLIED: [->Dps5: Inferno] "", nil, 0x0, Player-1-00000005, Dps5, 0x511, 461111, Inferno, 0, DEBUFF, 0
+		AntiSpam: gtfo
+		ShowSpecialWarning: Inferno damage - move away
+		PlaySound: VoicePack/watchfeet
 	[157.44] SPELL_CAST_SUCCESS: [Baron Geddon: Ignite Mana] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, "", nil, 0x0, 19659, Ignite Mana, 0, 0
 		StartTimer: 27.0, Ignite Mana
 	[157.44] SPELL_AURA_APPLIED: [Baron Geddon->Dps1: Ignite Mana] Creature-0-1-409-1-228433-0000000001, Baron Geddon, 0xa48, Player-1-00000001, Dps1, 0x512, 19659, Ignite Mana, 0, DEBUFF, 0


### PR DESCRIPTION
Blocks are a new experimental thing to reduce repetitive code for recurring patterns in mods. I'll be using the Geddon mod as a first example as it has two common patterns: Gtfo warnings and bombs on players.

As a side-effect this fixes a bug about a Gtfo warning not working properly in SoD