### PR TITLE
AQ20/Buru: Fix trigger for Pursue warning

### DIFF
--- a/DBM-Raids-Vanilla/AQ20/Buru.lua
+++ b/DBM-Raids-Vanilla/AQ20/Buru.lua
@@ -73,6 +73,7 @@ function mod:SPELL_AURA_REMOVED(args)
 end
 
 function mod:CHAT_MSG_MONSTER_EMOTE(msg, _, _, _, target)
+	-- "<15.57 22:24:07> [CHAT_MSG_MONSTER_EMOTE] %s sets eyes on Exikør!#Buru the Gorger###Exikør##0#0##0#914#nil#0#false#false#false#false",
 	if not msg:find(L.PursueEmote) then return end
 	if target then
 		target = DBM:GetUnitFullName(target)

--- a/DBM-Raids-Vanilla/localization.br.lua
+++ b/DBM-Raids-Vanilla/localization.br.lua
@@ -62,7 +62,7 @@ L:SetOptionLocalization{
 	WarnDismember	= DBM_CORE_L.AUTO_ANNOUNCE_OPTIONS.spell:format(96)
 }
 L:SetMiscLocalization{
-	PursueEmote 	= "%s vê o"
+	PursueEmote 	= " vê o"
 }
 
 -------------

--- a/DBM-Raids-Vanilla/localization.cn.lua
+++ b/DBM-Raids-Vanilla/localization.cn.lua
@@ -213,7 +213,7 @@ L:SetOptionLocalization{
 	SpecWarnPursue	= "当你被追击的时候显示特別警告"
 }
 L:SetMiscLocalization{
-	PursueEmote 	= "%s凝视着%s!"
+	PursueEmote 	= "凝视着"
 }
 
 -------------

--- a/DBM-Raids-Vanilla/localization.de.lua
+++ b/DBM-Raids-Vanilla/localization.de.lua
@@ -212,7 +212,7 @@ L:SetOptionLocalization{
 	SpecWarnPursue	= "Spezialwarnung, wenn du verfolgt wirst"
 }
 L:SetMiscLocalization{
-	PursueEmote 	= "%s behält %s im Blickfeld!"
+	PursueEmote 	= "behält %S* im Blickfeld!"
 }
 
 -------------

--- a/DBM-Raids-Vanilla/localization.en.lua
+++ b/DBM-Raids-Vanilla/localization.en.lua
@@ -225,7 +225,7 @@ L:SetOptionLocalization{
 	WarnDismember	= DBM_CORE_L.AUTO_ANNOUNCE_OPTIONS.spell:format(96)
 }
 L:SetMiscLocalization{
-	PursueEmote 	= "%s sets eyes on %s!"
+	PursueEmote 	= " sets eyes on "
 }
 
 -------------

--- a/DBM-Raids-Vanilla/localization.es.lua
+++ b/DBM-Raids-Vanilla/localization.es.lua
@@ -215,7 +215,7 @@ L:SetOptionLocalization{
 	WarnDismember	= DBM_CORE_L.AUTO_ANNOUNCE_OPTIONS.spell:format(96)
 }
 L:SetMiscLocalization{
-	PursueEmote 	= "¡%s fija su mirada en %s!"
+	PursueEmote 	= "fija su mirada en"
 }
 
 -------------

--- a/DBM-Raids-Vanilla/localization.fr.lua
+++ b/DBM-Raids-Vanilla/localization.fr.lua
@@ -62,7 +62,7 @@ L:SetOptionLocalization{
 	WarnDismember	= DBM_CORE_L.AUTO_ANNOUNCE_OPTIONS.spell:format(96)
 }
 L:SetMiscLocalization{
-	PursueEmote 	= "%s pose ses yeux sur"
+	PursueEmote 	= "pose ses yeux sur"
 }
 
 -------------

--- a/DBM-Raids-Vanilla/localization.mx.lua
+++ b/DBM-Raids-Vanilla/localization.mx.lua
@@ -62,7 +62,7 @@ L:SetOptionLocalization{
 	WarnDismember	= DBM_CORE_L.AUTO_ANNOUNCE_OPTIONS.spell:format(96)
 }
 L:SetMiscLocalization{
-	PursueEmote 	= "¡%s mira a"
+	PursueEmote 	= "mira a"
 }
 
 -------------

--- a/DBM-Raids-Vanilla/localization.ru.lua
+++ b/DBM-Raids-Vanilla/localization.ru.lua
@@ -226,7 +226,6 @@ L:SetOptionLocalization{
 	WarnDismember	= DBM_CORE_L.AUTO_ANNOUNCE_OPTIONS.spell:format(96)
 }
 L:SetMiscLocalization{
-	PursueEmote 	= "%s sets eyes on %s!"
 }
 
 -------------

--- a/DBM-Raids-Vanilla/localization.tw.lua
+++ b/DBM-Raids-Vanilla/localization.tw.lua
@@ -212,7 +212,7 @@ L:SetOptionLocalization{
 	SpecWarnPursue	= "當你被追擊的時候顯示特別警告"
 }
 L:SetMiscLocalization{
-	PursueEmote 	= "%s凝視著%s!"
+	PursueEmote 	= "凝視著"
 }
 
 -------------


### PR DESCRIPTION
It's used as a regex, hence the %s doesn't work as expected, just use the main part of the string as it's an in-combat event anyways