### PR TITLE
Change Maexxna spiderling timer to be more deterministic

### DIFF
--- a/DBM-Azeroth/Ysondre.lua
+++ b/DBM-Azeroth/Ysondre.lua
@@ -100,7 +100,7 @@ function mod:SPELL_AURA_APPLIED(args)
 end
 mod.SPELL_AURA_APPLIED_DOSE = mod.SPELL_AURA_APPLIED
 
-function mod:UNIT_SPELLCAST_SUCCEEDED(uId, _, spellId)
+function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, spellId)
 	if spellId == 24819 and self:AntiSpam(5, 2) then--Lightning Wave
 		warningLightningWave:Show()
 		timerLightningWaveCD:Start()

--- a/DBM-Raids-Vanilla/AQ40/Viscidus.lua
+++ b/DBM-Raids-Vanilla/AQ40/Viscidus.lua
@@ -149,7 +149,7 @@ function mod:CHAT_MSG_MONSTER_EMOTE(msg)
 	end
 end
 
-function mod:UNIT_SPELLCAST_SUCCEEDED(uId, _, spellId)
+function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, spellId)
 	if spellId == 25926 or spellId == 1215736 then
 		self:SendSync("FrostWeakness", spellId)
 	end

--- a/DBM-Raids-Vanilla/BWL/Chromaggus.lua
+++ b/DBM-Raids-Vanilla/BWL/Chromaggus.lua
@@ -51,7 +51,7 @@ local warnVuln			= mod:NewAnnounce("WarnVulnerable", 1, nil, "SpellCaster", "War
 
 local specWarnBronze		= mod:NewSpecialWarningYou(23170, nil, nil, nil, 1, 8, nil, nil, "useitem")
 local specWarnFrenzy		= mod:NewSpecialWarningDispel(23128, "RemoveEnrage", nil, nil, 1, 6, nil, nil, "enrage")
-local specWarnBreathSoon	= mod:NewSpecialWarningSoon(17087, nil, nil, nil, 3, 2)
+local specWarnBreathSoon	= mod:NewSpecialWarningSoon(17087, nil, nil, nil, 3, 2, nil, nil, "breathsoon")
 
 local timerBreath		= mod:NewTimer(2, "TimerBreath", 23316, nil, nil, 2)
 local timerBreathCD		= mod:NewTimer(61.5, "TimerBreathCD", 23316, nil, nil, 2)

--- a/DBM-Raids-Vanilla/MC/Ragnaros.lua
+++ b/DBM-Raids-Vanilla/MC/Ragnaros.lua
@@ -159,7 +159,7 @@ function mod:CHAT_MSG_MONSTER_YELL(msg)
 	end
 end
 
-function mod:UNIT_SPELLCAST_SUCCEEDED(uId, _, spellId)
+function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, spellId)
 	if spellId == 20567 then--Ragnaros Submerge Visual
 		self:SendSync("Submerge")
 	end

--- a/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
@@ -26,7 +26,7 @@ mod:RegisterEventsInCombat(
 local warnWebWrap		= mod:NewTargetAnnounce(28622, 2, nil, "RangedDps|Healer")
 local warnEnrage 		= mod:NewSpellAnnounce(28747, 4)
 local warnEnrageSoon	= mod:NewSoonAnnounce(28747, 2)
-local warnSpidersNow	= mod:NewSpellAnnounce(29434, 4, "134321")
+local warnSpidersNow	= mod:NewSpellAnnounce(29434, 4, "134321", "-Dps")
 local warnSpidersSoon	= mod:NewSoonAnnounce(29434, 2, "134321")
 local warnWebSprayNow	= mod:NewSpellAnnounce(29484, 4)
 local warnWebSpraySoon	= mod:NewSoonAnnounce(29484, 3)

--- a/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
@@ -26,7 +26,7 @@ mod:RegisterEventsInCombat(
 local warnWebWrap		= mod:NewTargetAnnounce(28622, 2, nil, "RangedDps|Healer")
 local warnEnrage 		= mod:NewSpellAnnounce(28747, 4)
 local warnEnrageSoon	= mod:NewSoonAnnounce(28747, 2)
-local warnSpidersNow	= mod:NewSpellAnnounce(29434, 4, "134321", "-Dps")
+local warnSpidersNow	= mod:NewSpellAnnounce(29434, 4, "134321")
 local warnSpidersSoon	= mod:NewSoonAnnounce(29434, 2, "134321")
 local warnWebSprayNow	= mod:NewSpellAnnounce(29484, 4)
 local warnWebSpraySoon	= mod:NewSoonAnnounce(29484, 3)

--- a/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
@@ -32,7 +32,7 @@ local warnWebSprayNow	= mod:NewSpellAnnounce(29484, 4)
 local warnWebSpraySoon	= mod:NewSoonAnnounce(29484, 3)
 
 local specWarnWebWrap	= mod:NewSpecialWarningSwitch(28622, "RangedDps|Healer", nil, 2, 1, 2)
-local specWarnSpiders	= mod:NewSpecialWarningSwitch(29434, "Dps", nil, nil, 1, 2, nil, "134321", "killmob")
+local specWarnSpiders	= mod:NewSpecialWarningAdds(29434, "Dps", nil, nil, 2, 2, nil, "134321", "killmob")
 local yellWebWrap		= mod:NewYell(28622)
 
 local timerWebSpray		= mod:NewNextTimer(40.5, 29484, nil, nil, nil, 2)
@@ -104,7 +104,7 @@ function mod:OnSync(msg)
 		warnEnrageSoon:Show()
 	elseif msg == "SpidersNow" then
 		timerSpider:Stop()
-		if self.Options.SpecWarn29434switch then
+		if self.Options.SpecWarn29434adds then
 			specWarnSpiders:Show()
 			specWarnSpiders:Play("killmob")
 		else

--- a/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
@@ -8,7 +8,7 @@ else
 end
 
 mod:SetRevision("@file-date-integer@")
-mod:SetMinSyncRevision(20260522000000) -- 2026, May 22nd
+mod:SetMinSyncRevision(20260523000000) -- 2026, May 23rd
 mod:DisableHardcodedOptions()
 mod:SetCreatureID(15952)
 mod:SetEncounterID(1116)
@@ -19,23 +19,24 @@ mod:RegisterCombat("combat")
 
 mod:RegisterEventsInCombat(
 	"SPELL_AURA_APPLIED 28622 28747",
-	"SPELL_CAST_SUCCESS 29484"
+	"SPELL_CAST_SUCCESS 29484",
+	"UNIT_SPELLCAST_SUCCEEDED"
 )
 
 local warnWebWrap		= mod:NewTargetAnnounce(28622, 2, nil, "RangedDps|Healer")
-local warnWebSprayNow	= mod:NewSpellAnnounce(29484, 4)
-local warnWebSpraySoon	= mod:NewSoonAnnounce(29484, 3)
-local warnSpidersSoon	= mod:NewAnnounce("WarningSpidersSoon", 2, 17332)
-local warnSpidersNow	= mod:NewAnnounce("WarningSpidersNow", 4, 17332)
 local warnEnrage 		= mod:NewSpellAnnounce(28747, 4)
 local warnEnrageSoon	= mod:NewSoonAnnounce(28747, 2)
+local warnSpidersNow	= mod:NewSpellAnnounce(29434, 4, "134321")
+local warnSpidersSoon	= mod:NewSoonAnnounce(29434, 2, "134321")
+local warnWebSprayNow	= mod:NewSpellAnnounce(29484, 4)
+local warnWebSpraySoon	= mod:NewSoonAnnounce(29484, 3)
 
 local specWarnWebWrap	= mod:NewSpecialWarningSwitch(28622, "RangedDps|Healer", nil, 2, 1, 2)
 local yellWebWrap		= mod:NewYell(28622)
 
 local timerWebSpray		= mod:NewNextTimer(40.5, 29484, nil, nil, nil, 2)
 local timerWebWrap		= mod:NewVarTimer("v39.6-40.9", 28622, nil, "RangedDps|Healer", nil, 3)
-local timerSpider		= mod:NewTimer(30.7, "TimerSpider", 17332, nil, nil, 1)
+local timerSpider		= mod:NewNextTimer(30.7, 29434, nil, nil, nil, 1, "134321")
 
 mod.vb.warnEnrageSoon = false
 
@@ -45,7 +46,6 @@ function mod:OnCombatStart()
 	timerWebSpray:Start()
 	timerWebWrap:Start("v18.2-20.1")
 	warnSpidersSoon:Schedule(25.7)
-	warnSpidersNow:Schedule(30.7)
 	timerSpider:Start()
 	self:RegisterShortTermEvents(
 		"UNIT_HEALTH"
@@ -78,9 +78,14 @@ function mod:SPELL_CAST_SUCCESS(args)
 		warnWebSprayNow:Show()
 		warnWebSpraySoon:Schedule(35.5)
 		timerWebSpray:Start()
-		warnSpidersSoon:Schedule(25)
-		warnSpidersNow:Schedule(30)
+		warnSpidersSoon:Schedule(25.7)
 		timerSpider:Start()
+	end
+end
+
+function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, spellId)
+	if spellId == 29434 then
+		self:SendSync("SpidersNow")
 	end
 end
 
@@ -96,5 +101,8 @@ function mod:OnSync(msg)
 	if msg == "EnrageSoon" and not self.vb.warnEnrageSoon then
 		self.vb.warnEnrageSoon = true
 		warnEnrageSoon:Show()
+	elseif msg == "SpidersNow" then
+		warnSpidersNow:Show()
+		timerSpider:Stop()
 	end
 end

--- a/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
@@ -32,6 +32,7 @@ local warnWebSprayNow	= mod:NewSpellAnnounce(29484, 4)
 local warnWebSpraySoon	= mod:NewSoonAnnounce(29484, 3)
 
 local specWarnWebWrap	= mod:NewSpecialWarningSwitch(28622, "RangedDps|Healer", nil, 2, 1, 2)
+local specWarnSpiders	= mod:NewSpecialWarningSwitch(29434, "Dps", nil, nil, 1, 2, nil, "134321", "killmob")
 local yellWebWrap		= mod:NewYell(28622)
 
 local timerWebSpray		= mod:NewNextTimer(40.5, 29484, nil, nil, nil, 2)
@@ -102,7 +103,12 @@ function mod:OnSync(msg)
 		self.vb.warnEnrageSoon = true
 		warnEnrageSoon:Show()
 	elseif msg == "SpidersNow" then
-		warnSpidersNow:Show()
 		timerSpider:Stop()
+		if self.Options.SpecWarn29434switch then
+			specWarnSpiders:Show()
+			specWarnSpiders:Play("killmob")
+		else
+			warnSpidersNow:Show()
+		end
 	end
 end

--- a/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/ArachnidQuarter/Maexxna.lua
@@ -31,7 +31,7 @@ local warnSpidersSoon	= mod:NewSoonAnnounce(29434, 2, "134321")
 local warnWebSprayNow	= mod:NewSpellAnnounce(29484, 4)
 local warnWebSpraySoon	= mod:NewSoonAnnounce(29484, 3)
 
-local specWarnWebWrap	= mod:NewSpecialWarningSwitch(28622, "RangedDps|Healer", nil, 2, 1, 2)
+local specWarnWebWrap	= mod:NewSpecialWarningSwitch(28622, "RangedDps|Healer", nil, 2, 1, 2, nil, nil, "targetchange")
 local specWarnSpiders	= mod:NewSpecialWarningAdds(29434, "Dps", nil, nil, 2, 2, nil, "134321", "killmob")
 local yellWebWrap		= mod:NewYell(28622)
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/MilitaryQuarter/Horsemen.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/MilitaryQuarter/Horsemen.lua
@@ -49,7 +49,7 @@ local timerMarkCD				= mod:NewTimer(DBM:IsSeasonal("SeasonOfDiscovery") and 13 o
 local timerMeteorCD				= mod:NewVarTimer("v11.3-16.2", 28884, nil, false, nil, 3)
 local timerVoidZoneCD			= mod:NewVarTimer("v11.3-16.2", 28863, nil, nil, nil, 3)
 local timerHolyWrathCD			= mod:NewVarTimer("v11.3-16.2", 28883, nil, false, nil, 3)
-local timerBoneBarrier			= mod:NewBuffActiveTimer(20, 29061, nil, "Dps", nil, 5, nil, DBM_COMMON_L.DAMAGE_ICON)
+local timerBoneBarrier			= mod:NewTargetTimer(20, 29061, nil, "Dps", nil, 5, nil, DBM_COMMON_L.DAMAGE_ICON)
 
 local horsemenGuidCheck = {}
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/MilitaryQuarter/Razuvious.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/MilitaryQuarter/Razuvious.lua
@@ -30,7 +30,7 @@ local warnShoutNow			= mod:NewSpellAnnounce(29107, 4, 6673)
 local warnShoutSoon			= mod:NewSoonAnnounce(29107, 3, 6673, "ManaUser")
 local warnShieldWall		= mod:NewTargetNoFilterAnnounce(29061, 2, nil, "Dps")
 
-local timerShout			= mod:NewCDTimer(25.9, 29107, nil, "ManaUser", nil, 2, 6673, DBM_COMMON_L.DEADLY_ICON, true, 1, 5)
+local timerShout			= mod:NewCDTimer(25.9, 29107, nil, "ManaUser", nil, 2, 6673, DBM_COMMON_L.DEADLY_ICON, nil, 1, 5)
 local timerTaunt			= mod:NewCDTimer(60, 29060, nil, isPriest, nil, 5, nil, DBM_COMMON_L.TANK_ICON)
 local timerShieldWall		= mod:NewBuffActiveTimer(20, 29061, nil, "Dps", nil, 5, nil, DBM_COMMON_L.DAMAGE_ICON)
 local timerMindExhaustionCD	= mod:NewCDNPTimer(60, 29051, nil, isPriest, nil, 5)

--- a/DBM-Raids-Vanilla/VanillaZG/Arlokk.lua
+++ b/DBM-Raids-Vanilla/VanillaZG/Arlokk.lua
@@ -66,7 +66,7 @@ function mod:SPELL_AURA_REMOVED(args)
 	end
 end
 
-function mod:UNIT_SPELLCAST_SUCCEEDED(uId, _, spellId)
+function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, spellId)
 	if not self.vb.vanished and spellId == 24223 then
 		self:SendSync("Vanish")
 	end

--- a/DBM-Raids-Vanilla/VanillaZG/Venoxis.lua
+++ b/DBM-Raids-Vanilla/VanillaZG/Venoxis.lua
@@ -93,7 +93,7 @@ function mod:UNIT_HEALTH(uId)
 	end
 end
 
-function mod:UNIT_SPELLCAST_SUCCEEDED(uId, _, spellId)
+function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, spellId)
    if self:GetStage(1.5) and spellId == 23849 then
 		self:SendSync("Phase", 2)
    end

--- a/DBM-Raids-Vanilla/localization.br.lua
+++ b/DBM-Raids-Vanilla/localization.br.lua
@@ -826,21 +826,6 @@ L:SetGeneralLocalization({
 	name = "Maexxna"
 })
 
-L:SetWarningLocalization({
-	WarningSpidersSoon	= "Proles de Maexxna em 5 segundos",
-	WarningSpidersNow	= "Proles de Maexxna"
-})
-
-L:SetTimerLocalization({
-	TimerSpider	= "Proles"
-})
-
-L:SetOptionLocalization({
-	WarningSpidersSoon	= "Exibir anúncio antecipado para quando as Proles de Maexxna aparecerem",
-	WarningSpidersNow	= "Exibir anúncio quando as Proles de Maexxna aparecerem",
-	TimerSpider			= "Exibir cronômetro para as próximas Proles de Maexxna"
-})
-
 -----------------------
 -- Noth the Plaguebringer --
 -----------------------

--- a/DBM-Raids-Vanilla/localization.br.lua
+++ b/DBM-Raids-Vanilla/localization.br.lua
@@ -193,6 +193,7 @@ L = DBM:GetModLocalization("Huhuran")
 L:SetGeneralLocalization{
 	name = "Princesa Huhuran"
 }
+
 ---------------
 -- Twin Emps --
 ---------------
@@ -242,6 +243,7 @@ L:SetMiscLocalization{
 	Weakened 	= "enfraquece!",
 	NotValid	= "AQ40 parcialmente limpo. %s chefes opcionais permanecem."
 }
+
 ----------------
 -- Ouro --
 ----------------
@@ -401,6 +403,7 @@ L:SetGeneralLocalization{
 L:SetMiscLocalization{
 	Ghosts = "Fantasmas"
 }
+
 -----------------
 --  Razorgore  --
 -----------------
@@ -430,6 +433,7 @@ L:SetGeneralLocalization{
 L:SetMiscLocalization{
 	Event				= "É tarde demais, meus amigos! A corrupção de Nefarius se espalhou... não consigo... me controlar."
 }
+
 -----------------
 --  Broodlord  --
 -----------------
@@ -469,6 +473,7 @@ L = DBM:GetModLocalization("Flamegor")
 L:SetGeneralLocalization{
 	name = "Flamagor"
 }
+
 ----------------
 --  Ebonroc and Flamegor  --
 ----------------
@@ -489,6 +494,7 @@ L:SetMiscLocalization{
 	Ebonroc		= "Petrébano",
 	Flamegor	= "Flamagor"
 }
+
 -----------------------
 --  Vulnerabilities  --
 -----------------------
@@ -608,6 +614,7 @@ SpecWarnBothBombs			= "Exibir anúncio especial se as bombas azul e verde estive
 SpecWarnBothBombsYou		= "Exibir anúncio especial se as bombas azul e verde estiverem em você",
 TimerBombs					= "Exibir cronômetro para as bombas de teste azul e verde"
 }
+
 ----------------
 --  Lucifron  --
 ----------------
@@ -739,6 +746,7 @@ L:SetOptionLocalization{
 L:SetWarningLocalization{
 	WarnBossPower		= "Energia do chefe em %d%%"
 }
+
 -----------------
 --  MC: Trash  --
 -----------------
@@ -912,7 +920,7 @@ L:SetOptionLocalization({
 })
 
 ---------------
--- Retalhoso --
+-- Patchwerk --
 ---------------
 L = DBM:GetModLocalization("PatchwerkVanilla")
 
@@ -1061,6 +1069,7 @@ L:SetMiscLocalization({
 	Blaumeux	= "Lady Blaumeux",
 	Zeliek		= "Sir Zeliek"
 })
+
 ---------------
 -- Sapphiron --
 ---------------

--- a/DBM-Raids-Vanilla/localization.cn.lua
+++ b/DBM-Raids-Vanilla/localization.cn.lua
@@ -751,21 +751,6 @@ L:SetGeneralLocalization({
 	name 					= "迈克斯纳"
 })
 
-L:SetWarningLocalization({
-	WarningSpidersSoon		= "迈克斯纳的小蜘蛛5秒后出现",
-	WarningSpidersNow		= "迈克斯纳的小蜘蛛出现了"
-})
-
-L:SetTimerLocalization({
-	TimerSpider				= "迈克斯纳的小蜘蛛"
-})
-
-L:SetOptionLocalization({
-	WarningSpidersSoon		= "迈克斯纳的小蜘蛛显示提前警报",
-	WarningSpidersNow		= "迈克斯纳的小蜘蛛显示警报",
-	TimerSpider				= "为下一次迈克斯纳的小蜘蛛显示计时条"
-})
-
 ------------------------------
 --  Noth the Plaguebringer  --
 ------------------------------

--- a/DBM-Raids-Vanilla/localization.de.lua
+++ b/DBM-Raids-Vanilla/localization.de.lua
@@ -802,21 +802,6 @@ L:SetGeneralLocalization({
 	name = "Maexxna"
 })
 
-L:SetWarningLocalization({
-	WarningSpidersSoon	= "Maexxnaspinnlinge in 5 Sek",
-	WarningSpidersNow	= "Maexxnaspinnlinge erschienen"
-})
-
-L:SetTimerLocalization({
-	TimerSpider	= "Maexxnaspinnlinge"
-})
-
-L:SetOptionLocalization({
-	WarningSpidersSoon	= "Zeige Vorwarnung für Maexxnaspinnlinge",
-	WarningSpidersNow	= "Zeige Warnung für Maexxnaspinnlinge",
-	TimerSpider			= "Zeige Zeit bis nächste Maexxnaspinnlinge erscheinen"
-})
-
 ------------------------------
 --  Noth the Plaguebringer  --
 ------------------------------

--- a/DBM-Raids-Vanilla/localization.en.lua
+++ b/DBM-Raids-Vanilla/localization.en.lua
@@ -848,21 +848,6 @@ L:SetGeneralLocalization({
 	name = "Maexxna"
 })
 
-L:SetWarningLocalization({
-	WarningSpidersSoon	= "Maexxna Spiderlings in 5 seconds",
-	WarningSpidersNow	= "Maexxna Spiderlings spawned"
-})
-
-L:SetTimerLocalization({
-	TimerSpider	= "Next Maexxna Spiderlings"
-})
-
-L:SetOptionLocalization({
-	WarningSpidersSoon	= "Show pre-warning for Maexxna Spiderlings",
-	WarningSpidersNow	= "Show warning for Maexxna Spiderlings",
-	TimerSpider			= "Show timer for next Maexxna Spiderlings"
-})
-
 ------------------------------
 --  Noth the Plaguebringer  --
 ------------------------------

--- a/DBM-Raids-Vanilla/localization.es.lua
+++ b/DBM-Raids-Vanilla/localization.es.lua
@@ -840,21 +840,6 @@ L:SetGeneralLocalization({
 	name = "Maexxna"
 })
 
-L:SetWarningLocalization({
-	WarningSpidersSoon	= "Arañitas Maexxna en 5 segundos",
-	WarningSpidersNow	= "Arañitas Maexxna"
-})
-
-L:SetTimerLocalization({
-	TimerSpider	= "Arañitas"
-})
-
-L:SetOptionLocalization({
-	WarningSpidersSoon	= "Mostrar anuncio anticipado para cuando aparezcan Arañitas Maexxna",
-	WarningSpidersNow	= "Mostrar anuncio cuando aparezcan Arañitas Maexxna",
-	TimerSpider			= "Mostrar temporizador para las próximas Arañitas Maexxna"
-})
-
 -----------------------
 -- Noth el Pesteador --
 -----------------------

--- a/DBM-Raids-Vanilla/localization.fr.lua
+++ b/DBM-Raids-Vanilla/localization.fr.lua
@@ -813,7 +813,7 @@ L:SetWarningLocalization({
 })
 
 L:SetOptionLocalization({
-	WarningEmbraceExpire	= "AAfficher une pré-annonce lorsque $spell:28732 se dissipe"
+	WarningEmbraceExpire	= "Afficher une pré-annonce lorsque $spell:28732 se dissipe"
 })
 
 L:SetMiscLocalization({
@@ -829,21 +829,6 @@ L = DBM:GetModLocalization("MaexxnaVanilla")
 
 L:SetGeneralLocalization({
 	name = "Maexxna"
-})
-
-L:SetWarningLocalization({
-	WarningSpidersSoon	= "Jeunes araignées de Maexxna dans 5 sec",
-	WarningSpidersNow	= "Jeunes araignées de Maexxna"
-})
-
-L:SetTimerLocalization({
-	TimerSpider			= "Jeunes araignées"
-})
-
-L:SetOptionLocalization({
-	WarningSpidersSoon	= "Afficher une pré-annonce pour les Jeunes araignées de Maexxna",
-	WarningSpidersNow	= "Afficher une annonce pour les Jeunes araignées de Maexxna",
-	TimerSpider			= "Afficher un chronomètre pour l'arrivée des Jeunes araignées de Maexxna"
 })
 
 ------------------------------

--- a/DBM-Raids-Vanilla/localization.kr.lua
+++ b/DBM-Raids-Vanilla/localization.kr.lua
@@ -850,21 +850,6 @@ L:SetGeneralLocalization({
 	name = "맥스나"
 })
 
-L:SetWarningLocalization({
-	WarningSpidersSoon	= "5초 후 맥스나의 새끼 거미",
-	WarningSpidersNow	= "맥스나의 새끼 거미 등장"
-})
-
-L:SetTimerLocalization({
-	TimerSpider		= "맥스나의 새끼 거미"
-})
-
-L:SetOptionLocalization({
-	WarningSpidersSoon	= "맥스나의 새끼 거미 사전 경고 보기",
-	WarningSpidersNow	= "맥스나의 새끼 거미 알림 보기",
-	TimerSpider			= "다음 맥스나의 새끼 거미 타이머 바 보기"
-})
-
 ------------------------------
 --  Noth the Plaguebringer  --
 ------------------------------

--- a/DBM-Raids-Vanilla/localization.mx.lua
+++ b/DBM-Raids-Vanilla/localization.mx.lua
@@ -830,21 +830,6 @@ L:SetGeneralLocalization({
 	name = "Maexxna"
 })
 
-L:SetWarningLocalization({
-	WarningSpidersSoon	= "Arañitas de Maexxna en 5 segundos",
-	WarningSpidersNow	= "Arañitas de Maexxna"
-})
-
-L:SetTimerLocalization({
-	TimerSpider	= "Arañitas"
-})
-
-L:SetOptionLocalization({
-	WarningSpidersSoon	= "Mostrar anuncio anticipado para cuando aparezcan Arañitas de Maexxna",
-	WarningSpidersNow	= "Mostrar anuncio cuando aparezcan Arañitas de Maexxna",
-	TimerSpider			= "Mostrar temporizador para las próximas Arañitas de Maexxna"
-})
-
 -----------------------
 -- Noth el Pesteador --
 -----------------------

--- a/DBM-Raids-Vanilla/localization.ru.lua
+++ b/DBM-Raids-Vanilla/localization.ru.lua
@@ -854,21 +854,6 @@ L:SetGeneralLocalization({
 	name = "Мексна"
 })
 
-L:SetWarningLocalization({
-	WarningSpidersSoon	= "Паученыши Мексны через 5 сек.",
-	WarningSpidersNow	= "В паутине появляются паучата"
-})
-
-L:SetTimerLocalization({
-	TimerSpider	= "Паученыши Мексны"
-})
-
-L:SetOptionLocalization({
-	WarningSpidersSoon	= "Показывать предупреждение перед следующим призывом Паученышей Мексны",
-	WarningSpidersNow	= "Показывать предупреждение для призыва Паученышей Мексны",
-	TimerSpider			= "Отсчет времени до появления Паученышей Мексны"
-})
-
 ------------------------------
 --  Noth the Plaguebringer  --
 ------------------------------

--- a/DBM-Raids-Vanilla/localization.tw.lua
+++ b/DBM-Raids-Vanilla/localization.tw.lua
@@ -752,21 +752,6 @@ L:SetGeneralLocalization({
 	name = "梅克絲娜"
 })
 
-L:SetWarningLocalization({
-	WarningSpidersSoon	= "梅克絲娜之子5秒後出現",
-	WarningSpidersNow	= "梅克絲娜之子出現了"
-})
-
-L:SetTimerLocalization({
-	TimerSpider	= "梅克絲娜之子"
-})
-
-L:SetOptionLocalization({
-	WarningSpidersSoon	= "為梅克絲娜之子顯示預先警告",
-	WarningSpidersNow	= "為梅克絲娜之子顯示警告",
-	TimerSpider			= "為下一次梅克絲娜之子顯示計時器"
-})
-
 ------------------------------
 --  Noth the Plaguebringer  --
 ------------------------------


### PR DESCRIPTION
This PR will make the timers for Maexxna spiderlings be more deterministic and based on the cast of Spell ID 29434

Using the spell ID also makes the localization not necessary

I also removed uID from some functions for UNIT_SPELLCAST_SUCCEEDED where the uID is not being used by the function. Also found a minor typo for French localization for Faerlina.