### PR TITLE
Minor Fixes

### DIFF
--- a/DBM-Raids-Vanilla/VanillaNaxx/ConstructQuarter/Thaddius.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/ConstructQuarter/Thaddius.lua
@@ -40,7 +40,7 @@ local timerEnrage			= mod:NewBerserkTimer(300)
 local timerNextShift		= mod:NewVarTimer("v25.9-35.7", 28089, nil, nil, nil, 2, nil, DBM_COMMON_L.DEADLY_ICON)
 local timerShiftCast		= mod:NewCastTimer(3, 28089, nil, nil, nil, 2)
 local timerThrow			= mod:NewCDTimer(20.6, 28338, nil, nil, nil, 5, nil, DBM_COMMON_L.TANK_ICON)
-local timerIntermission		= mod:NewIntermissionTimer("v3.2-4.8", nil, CL.INTERMISSION, true, nil, nil, "136106")
+local timerIntermission		= mod:NewIntermissionTimer("v1.6-4.8", nil, CL.INTERMISSION, true, nil, nil, "136106")
 
 mod:AddInfoFrameOption()
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
@@ -30,8 +30,8 @@ ability.id = 28524 and type = "begincast"
 --]]
 local airPhaseTimer = "v54.3-70.8"
 
-local warnDrainLifeNow	= mod:NewSpellAnnounce(28542, 2)
-local warnDrainLifeSoon	= mod:NewSoonAnnounce(28542, 1, nil, "RemoveCurse")
+local warnDrainLifeNow	= mod:NewSpellAnnounce(28542, 3)
+local warnDrainLifeSoon	= mod:NewSoonAnnounce(28542, 2, nil, "RemoveCurse")
 local warnIceBlock
 if DBM:IsSeasonal("SeasonOfDiscovery") then
 	warnIceBlock		= mod:NewTargetCountAnnounce(28522, 2)

--- a/DBM-Raids-Vanilla/VanillaNaxx/NaxxTrash.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/NaxxTrash.lua
@@ -14,7 +14,7 @@ mod:RegisterEvents(
 local warnIntimidatingShout		= mod:NewSpellAnnounce(19134, 2)
 local warnFear					= mod:NewSpellAnnounce(27990, 2)
 local specWarnLightningTotem	= mod:NewSpecialWarningSwitch(28294, "Dps", nil, nil, 3, 2, nil, nil, "attacktotem")
-local warnPoisonCharge			= mod:NewSpellAnnounce(28431, 2, nil, "RemovePoison")
+local warnPoisonCharge			= mod:NewSpellAnnounce(28431, 2)
 local warnVeilofShadow			= mod:NewSpellAnnounce(28440, 2, nil, "RemoveCurse|Healer")
 
 function mod:SPELL_SUMMON(args)

--- a/DBM-Raids-Vanilla/localization.es.lua
+++ b/DBM-Raids-Vanilla/localization.es.lua
@@ -803,7 +803,7 @@ L:SetGeneralLocalization({
 
 L:SetMiscLocalization({
 	Pull1				= "Eso... ¡Corred! ¡Así la sangre bombeará más rápido!",
-	Pull2				= "Solo un bocado...",
+	Pull2				= "Solo un poco...",
 	Pull3				= "No hay salida."
 })
 


### PR DESCRIPTION
1. Drain Life is not a beneficial spell so a color classification of 1 is inappropriate
2. Other minor timer / warning role fixes
3. Minor localization fixes

Feel free to merge this whenever you plan on releasing a new version of DBM-Vanilla. There is no rush on this and I'll just keep adding to it as I keep running raids. But it's good to merge whenever. 

There is no intention to make any fundamental changes to the code in this PR, only minor timer/warning adjustments.