### PR TITLE
Spell Warning option name for Shazzrah

### DIFF
--- a/DBM-Raids-Vanilla/MC/Shazzrah.lua
+++ b/DBM-Raids-Vanilla/MC/Shazzrah.lua
@@ -73,7 +73,7 @@ end
 
 function mod:SPELL_AURA_APPLIED(args)
 	if args:IsSpell(19714) and not args:IsDestTypePlayer() then
-		if self.Options.SpecWarn19714dispel then
+		if self.Options.SpecWarn19714dispel2 then
 			specWarnDeadenMagic:Show(args.destName)
 			specWarnDeadenMagic:Play("dispelboss")
 		else
@@ -81,7 +81,7 @@ function mod:SPELL_AURA_APPLIED(args)
 		end
 		timerDeadenMagic:Start()
 	elseif args:IsSpell(460856) and not args:IsDestTypePlayer() then
-		if self.Options.SpecWarn19714dispel then
+		if self.Options.SpecWarn19714dispel2 then
 			specWarnReflectMagicDispel:Show(args.destName)
 			specWarnReflectMagicDispel:Play("dispelboss")
 		end


### PR DESCRIPTION
When I prompted AI about why this dispel special warning didn't show up when I have the option enabled, it said because the constructor is using version 2, the name needs to be updated accordingly.

The timer went off so I know the SPELL_AURA_APPLIED fired, but that if statement inside for the special warning did not.