### PR TITLE
Update localization.es.lua

### DIFF
--- a/DBM-Raids-Vanilla/localization.es.lua
+++ b/DBM-Raids-Vanilla/localization.es.lua
@@ -997,7 +997,7 @@ L:SetGeneralLocalization({
 L:SetMiscLocalization({
 	Pull1 = "¡No muestres misericordia!",
 	Pull2 = "¡Se acabado la práctica! ¡Enseñadme lo que habéis aprendido!",
-	Pull3 = "¡Poned en práctica lo que os he enseñado!",
+	Pull3 = "¡Hazlo como te enseñé!",
 	Pull4 = "Arrastra la pierna... ¿Tienes algún problema con eso?"
 })
 


### PR DESCRIPTION
I think Blizzard changed some of these strings, or the strings are different in Era versus Anniversary, or there are multiple strings that have the same English equivalent.

Still wish we could get rid of all of them :)