### PR TITLE
Update Ouro.lua

### DIFF
--- a/DBM-Raids-Vanilla/AQ40/Ouro.lua
+++ b/DBM-Raids-Vanilla/AQ40/Ouro.lua
@@ -78,10 +78,8 @@ function mod:SPELL_AURA_APPLIED(args)
 		self.vb.berserked = true
 		warnBerserk:Show()
 		timerSubmerge:Stop()
-		if timerBlastCD then
-			timerBlastCD:Stop()
-            timerBlastCD:Start()
-		end
+		timerBlastCD:Stop() -- Sand Blast timer resets when Ouro enrages
+        timerBlastCD:Start()
 	end
 end
 

--- a/DBM-Raids-Vanilla/AQ40/Ouro.lua
+++ b/DBM-Raids-Vanilla/AQ40/Ouro.lua
@@ -36,7 +36,7 @@ local specWarnBlast		= mod:NewSpecialWarningSpell(26102, nil, nil, nil, 2, 2, ni
 
 local timerSubmerge		= mod:NewTimer(30, "TimerSubmerge", "Interface\\AddOns\\DBM-Core\\textures\\CryptFiendBurrow.blp", nil, nil, 6)
 local timerEmerge		= mod:NewTimer(30, "TimerEmerge", "Interface\\AddOns\\DBM-Core\\textures\\CryptFiendUnBurrow.blp", nil, nil, 6)
-local timerBlastCD		= mod:NewVarTimer("v22.1-38.9", 26102, nil, nil, nil, 2)
+local timerBlastCD		= mod:NewVarTimer("v22.1-26.8", 26102, nil, nil, nil, 2)
 local timerSweepCD		= mod:NewVarTimer("v20.6-22.6", 26103, nil, "Tank", 2, 5, nil, DBM_COMMON_L.TANK_ICON)
 
 local timerNextEye, specWarnEye
@@ -78,6 +78,10 @@ function mod:SPELL_AURA_APPLIED(args)
 		self.vb.berserked = true
 		warnBerserk:Show()
 		timerSubmerge:Stop()
+		if timerBlastCD:IsStarted() then
+			timerBlastCD:Stop()
+            timerBlastCD:Start()
+		end
 	end
 end
 

--- a/DBM-Raids-Vanilla/AQ40/Ouro.lua
+++ b/DBM-Raids-Vanilla/AQ40/Ouro.lua
@@ -78,7 +78,7 @@ function mod:SPELL_AURA_APPLIED(args)
 		self.vb.berserked = true
 		warnBerserk:Show()
 		timerSubmerge:Stop()
-		if timerBlastCD:IsStarted() then
+		if timerBlastCD then
 			timerBlastCD:Stop()
             timerBlastCD:Start()
 		end


### PR DESCRIPTION
The timer for Ouro's sand blast resets when he enrages. The WCL data that I had collected did not have this context, and therefore the CD timers variation range was much larger than what is real. Therefore, this PR modifies the CD timer to a much smaller band, and resets the timer when Ouro enrages.