### PR TITLE
Update Noth.lua

### DIFF
--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -38,7 +38,7 @@ local specWarnAdds		= mod:NewSpecialWarningAdds(29212, "-Healer", nil, nil, 1, 2
 
 local timerTeleport		= mod:NewTimer(90, "TimerTeleport", "135736", nil, nil, 6)
 local timerTeleportBack	= mod:NewTimer(70, "TimerTeleportBack", "135736", nil, nil, 6)
-local timerCurse       	= mod:NewBuffActiveTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
+local timerCurse       	= mod:NewBuffFadesTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerCurseCD		= mod:NewVarTimer("v51.8-118.9", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerAddsCD		= mod:NewAddsTimer(30, 29212, nil, "-Healer")
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -40,7 +40,7 @@ local timerTeleport		= mod:NewTimer(90, "TimerTeleport", "135736", nil, nil, 6)
 local timerTeleportBack	= mod:NewTimer(70, "TimerTeleportBack", "135736", nil, nil, 6)
 local timerCurse       	= mod:NewBuffFadesTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerCurseCD		= mod:NewVarTimer("v51.7-68", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
-local timerAddsCD		= mod:NewAddsTimer(30, 29252, nil, "-Healer", 1, "136187")
+local timerAddsCD		= mod:NewAddsTimer(30, 29252, nil, "-Healer", nil, 1, "136187")
 
 mod:AddInfoFrameOption(29213, "RemoveCurse")
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -34,13 +34,13 @@ local warnTeleportSoon	= mod:NewAnnounce("WarningTeleportSoon", 1, "135736")
 local warnCurse			= mod:NewSpellAnnounce(29213, 2)
 local warnBlink			= mod:NewSpellAnnounce(29208, 3)
 
-local specWarnAdds		= mod:NewSpecialWarningAdds(29212, "-Healer", nil, nil, 1, 2, nil, nil, "killmob")
+local specWarnAdds		= mod:NewSpecialWarningAdds(29252, "-Healer", nil, nil, 1, 2, nil, "136187", "killmob")
 
 local timerTeleport		= mod:NewTimer(90, "TimerTeleport", "135736", nil, nil, 6)
 local timerTeleportBack	= mod:NewTimer(70, "TimerTeleportBack", "135736", nil, nil, 6)
 local timerCurse       	= mod:NewBuffFadesTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerCurseCD		= mod:NewVarTimer("v51.7-68", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
-local timerAddsCD		= mod:NewAddsTimer(30, 29212, nil, "-Healer")
+local timerAddsCD		= mod:NewAddsTimer(30, 29252, nil, "-Healer", 1, "136187")
 
 mod:AddInfoFrameOption(29213, "RemoveCurse")
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -122,7 +122,7 @@ function mod:OnCombatStart()
 	self.vb.teleCount = 0
 	self.vb.addsCount = 0
 	self.vb.curseCount = 0
-	timerAddsCD:Start("v8.1-21")
+	timerAddsCD:Start("v8.1-22.7")
 	timerCurseCD:Start("v6.5-25.9")
 	timerTeleport:Start(90.8)
 	warnTeleportSoon:Schedule(70.8)

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -8,7 +8,6 @@ else
 end
 
 mod:SetRevision("@file-date-integer@")
-mod:SetMinSyncRevision(20260618000000) -- 2026, June 18th
 mod:DisableHardcodedOptions()
 mod:SetCreatureID(15954)
 mod:SetEncounterID(1117)
@@ -21,7 +20,7 @@ mod:RegisterEventsInCombat(
 	"SPELL_CAST_SUCCESS 29213 29212 29208",
 	"SPELL_AURA_APPLIED 29213",
 	"SPELL_AURA_REMOVED 29213",
-	"UNIT_SPELLCAST_SUCCEEDED"
+	"CHAT_MSG_MONSTER_YELL"
 )
 
 --TODO, determine if old way is required or if new way is still functional
@@ -181,8 +180,8 @@ function mod:SPELL_CAST_SUCCESS(args)
 	end
 end
 
-function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, spellId)
-	if spellId == 29237 or spellId == 29252 or spellId == 29265 or spellId == 29270 then
+function mod:CHAT_MSG_MONSTER_YELL(msg)
+	if if msg == L.AddsYell or msg:find(L.AddsYell) then
 		self:SendSync("Adds")
 	end
 end

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -35,6 +35,7 @@ local warnCurse			= mod:NewSpellAnnounce(29213, 2)
 local warnBlink			= mod:NewSpellAnnounce(29208, 3)
 
 local specWarnAdds		= mod:NewSpecialWarningAdds(29252, "-Healer", nil, nil, 1, 2, nil, "136187", "killmob")
+local specWarnCurse 	= mod:NewSpecialWarningDispel(29213, "RemoveCurse", nil, nil, 1, 2, nil, nil, "dispelnow")
 
 local timerTeleport		= mod:NewTimer(90, "TimerTeleport", "135736", nil, nil, 6)
 local timerTeleportBack	= mod:NewTimer(70, "TimerTeleportBack", "135736", nil, nil, 6)
@@ -152,6 +153,10 @@ function mod:SPELL_AURA_APPLIED(args)
 	if args:IsSpell(29213) then
 		curseTargets[args.destName] = true
 		UpdateCurseFrame()
+		if self.Options.SpecWarn29213dispel and self:AntiSpam(3, 1) then
+			specWarnCurse:CombinedShow(0.5, args.destName)
+			specWarnCurse:ScheduleVoice(0.5, "dispelnow")
+		end
 	end
 end
 
@@ -165,8 +170,10 @@ end
 function mod:SPELL_CAST_SUCCESS(args)
 	if args:IsSpell(29213) then -- Curse of the Plaguebringer
 		self.vb.curseCount = self.vb.curseCount + 1
-		warnCurse:Show()
 		timerCurse:Start()
+		if not self.Options.SpecWarn29213dispel then
+			warnCurse:Show()
+		end
 		if self.vb.teleCount == 2 and self.vb.curseCount == 2 or self.vb.teleCount == 3 and self.vb.curseCount == 1 then
 			timerCurseCD:Start(67)--Niche cases it's 67 and not 53-55
 		elseif self.vb.curseCount < 2 then

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -194,7 +194,7 @@ function mod:OnSync(msg)
 		specWarnAdds:Play("killmob")
 		if self.vb.teleCount < 4 then
 			if self.vb.teleCount == 0 and self.vb.addsCount < 3 then--3 waves, 12, 34, 34
-				timerAddsCD:Start("v25.9-37.2)
+				timerAddsCD:Start("v25.9-37.2")
 			elseif self.vb.teleCount == 1 then--3 waves, 3, 34, 30 (3 iffy)
 				if self.vb.addsCount == 1 then
 					timerAddsCD:Start(33.9)

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -166,7 +166,7 @@ function mod:SPELL_CAST_SUCCESS(args)
 	if args:IsSpell(29213) then -- Curse of the Plaguebringer
 		self.vb.curseCount = self.vb.curseCount + 1
 		warnCurse:Show()
-		timerCurse:Show()
+		timerCurse:Start()
 		if self.vb.teleCount == 2 and self.vb.curseCount == 2 or self.vb.teleCount == 3 and self.vb.curseCount == 1 then
 			timerCurseCD:Start(67)--Niche cases it's 67 and not 53-55
 		elseif self.vb.curseCount < 2 then

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -121,7 +121,7 @@ function mod:OnCombatStart()
 	self.vb.teleCount = 0
 	self.vb.addsCount = 0
 	self.vb.curseCount = 0
-	timerAddsCD:Start(12)
+	timerAddsCD:Start("v8.1-21")
 	timerCurseCD:Start("v6.5-25.9")
 	timerTeleport:Start(90.8)
 	warnTeleportSoon:Schedule(70.8)

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -39,7 +39,7 @@ local specWarnAdds		= mod:NewSpecialWarningAdds(29252, "-Healer", nil, nil, 1, 2
 local timerTeleport		= mod:NewTimer(90, "TimerTeleport", "135736", nil, nil, 6)
 local timerTeleportBack	= mod:NewTimer(70, "TimerTeleportBack", "135736", nil, nil, 6)
 local timerCurse       	= mod:NewBuffFadesTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
-local timerCurseCD		= mod:NewVarTimer("v51.7-68", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
+local timerCurseCD		= mod:NewVarTimer("v51.8-68", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerAddsCD		= mod:NewAddsTimer(30, 29252, nil, "-Healer", nil, 1, "136187")
 
 mod:AddInfoFrameOption(29213, "RemoveCurse")

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -18,6 +18,8 @@ mod:RegisterCombat("combat_yell", L.Pull1, L.Pull2, L.Pull3)
 
 mod:RegisterEventsInCombat(
 	"SPELL_CAST_SUCCESS 29213 29212 29208",
+	"SPELL_AURA_APPLIED 29213",
+	"SPELL_AURA_REMOVED 29213",
 	"CHAT_MSG_MONSTER_YELL"
 )
 
@@ -36,8 +38,28 @@ local specWarnAdds		= mod:NewSpecialWarningAdds(29212, "-Healer", nil, nil, 1, 2
 
 local timerTeleport		= mod:NewTimer(90, "TimerTeleport", "135736", nil, nil, 6)
 local timerTeleportBack	= mod:NewTimer(70, "TimerTeleportBack", "135736", nil, nil, 6)
+local timerCurse       	= mod:NewBuffActiveTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerCurseCD		= mod:NewVarTimer("v51.8-118.9", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerAddsCD		= mod:NewAddsTimer(30, 29212, nil, "-Healer")
+
+mod:AddInfoFrameOption(29213, "RemoveCurse")
+
+local lines, sortedLines = {}, {}
+local curseTargets = {}
+local function updateInfoFrame()
+	table.wipe(lines)
+	table.wipe(sortedLines)
+
+	local i = 0
+
+	for name in pairs(curseTargets) do
+		i = i + 1
+		sortedLines[i] = name
+		lines[name] = ""
+	end
+
+	return lines, sortedLines
+end
 
 mod.vb.teleCount = 0
 mod.vb.addsCount = 0
@@ -95,6 +117,7 @@ function mod:BackInRoom()
 end
 
 function mod:OnCombatStart()
+	table.wipe(curseTargets)
 	self.vb.teleCount = 0
 	self.vb.addsCount = 0
 	self.vb.curseCount = 0
@@ -105,10 +128,45 @@ function mod:OnCombatStart()
 	self:ScheduleMethod(90.8, "Balcony")
 end
 
+function mod:OnCombatEnd()
+	DBM.InfoFrame:Hide()
+	table.wipe(curseTargets)
+end
+
+local function UpdateCurseFrame()
+	if not mod.Options.InfoFrame then return end
+	if next(curseTargets) then
+		if not DBM.InfoFrame:IsShown() then
+			DBM.InfoFrame:SetHeader(DBM:GetSpellInfo(29213))
+			DBM.InfoFrame:Show(20, "function", updateInfoFrame)
+		else
+			DBM.InfoFrame:UpdateTable(updateInfoFrame)
+		end
+	else
+		DBM.InfoFrame:Hide()
+		timerCurse:Cancel()
+	end
+end
+
+function mod:SPELL_AURA_APPLIED(args)
+	if args:IsSpell(29213) then
+		curseTargets[args.destName] = true
+		UpdateCurseFrame()
+	end
+end
+
+function mod:SPELL_AURA_REMOVED(args)
+	if args:IsSpell(29213) then
+		curseTargets[args.destName] = nil
+		UpdateCurseFrame()
+	end
+end
+
 function mod:SPELL_CAST_SUCCESS(args)
 	if args:IsSpell(29213) then -- Curse of the Plaguebringer
 		self.vb.curseCount = self.vb.curseCount + 1
 		warnCurse:Show()
+		timerCurse:Show()
 		if self.vb.teleCount == 2 and self.vb.curseCount == 2 or self.vb.teleCount == 3 and self.vb.curseCount == 1 then
 			timerCurseCD:Start(67)--Niche cases it's 67 and not 53-55
 		elseif self.vb.curseCount < 2 then

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -39,7 +39,7 @@ local specWarnAdds		= mod:NewSpecialWarningAdds(29252, "-Healer", nil, nil, 1, 2
 local timerTeleport		= mod:NewTimer(90, "TimerTeleport", "135736", nil, nil, 6)
 local timerTeleportBack	= mod:NewTimer(70, "TimerTeleportBack", "135736", nil, nil, 6)
 local timerCurse       	= mod:NewBuffFadesTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
-local timerCurseCD		= mod:NewVarTimer("v51.8-68", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
+local timerCurseCD		= mod:NewVarTimer("v51.8-66.8", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerAddsCD		= mod:NewAddsTimer(30, 29252, nil, "-Healer", nil, 1, "136187")
 
 mod:AddInfoFrameOption(29213, "RemoveCurse")

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -38,8 +38,8 @@ local specWarnAdds		= mod:NewSpecialWarningAdds(29212, "-Healer", nil, nil, 1, 2
 
 local timerTeleport		= mod:NewTimer(90, "TimerTeleport", "135736", nil, nil, 6)
 local timerTeleportBack	= mod:NewTimer(70, "TimerTeleportBack", "135736", nil, nil, 6)
-local timerCurse       	= mod:NewBuffFadesTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
-local timerCurseCD		= mod:NewVarTimer("v51.8-115.6", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
+local timerCurse       	= mod:NewBuffActiveTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
+local timerCurseCD		= mod:NewVarTimer("v51.7-68", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerAddsCD		= mod:NewAddsTimer(30, 29212, nil, "-Healer")
 
 mod:AddInfoFrameOption(29213, "RemoveCurse")
@@ -180,8 +180,8 @@ function mod:SPELL_CAST_SUCCESS(args)
 	end
 end
 
-function mod:CHAT_MSG_MONSTER_YELL(msg, npc, _, _, target)
-	if msg == L.AddsYell or msg:find(L.AddsYell) then
+function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, spellId)
+	if spellId == 29237 or spellId == 29252 or spellId == 29265 or spellId == 29270 then
 		self:SendSync("Adds")
 	end
 end

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -8,6 +8,7 @@ else
 end
 
 mod:SetRevision("@file-date-integer@")
+mod:SetMinSyncRevision(20260618000000) -- 2026, June 18th
 mod:DisableHardcodedOptions()
 mod:SetCreatureID(15954)
 mod:SetEncounterID(1117)
@@ -20,7 +21,7 @@ mod:RegisterEventsInCombat(
 	"SPELL_CAST_SUCCESS 29213 29212 29208",
 	"SPELL_AURA_APPLIED 29213",
 	"SPELL_AURA_REMOVED 29213",
-	"CHAT_MSG_MONSTER_YELL"
+	"UNIT_SPELLCAST_SUCCEEDED"
 )
 
 --TODO, determine if old way is required or if new way is still functional

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -144,7 +144,7 @@ local function UpdateCurseFrame()
 		end
 	else
 		DBM.InfoFrame:Hide()
-		timerCurse:Cancel()
+		timerCurse:Stop()
 	end
 end
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -181,7 +181,7 @@ function mod:SPELL_CAST_SUCCESS(args)
 end
 
 function mod:CHAT_MSG_MONSTER_YELL(msg)
-	if if msg == L.AddsYell or msg:find(L.AddsYell) then
+	if msg == L.AddsYell or msg:find(L.AddsYell) then
 		self:SendSync("Adds")
 	end
 end

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -39,7 +39,7 @@ local specWarnAdds		= mod:NewSpecialWarningAdds(29212, "-Healer", nil, nil, 1, 2
 local timerTeleport		= mod:NewTimer(90, "TimerTeleport", "135736", nil, nil, 6)
 local timerTeleportBack	= mod:NewTimer(70, "TimerTeleportBack", "135736", nil, nil, 6)
 local timerCurse       	= mod:NewBuffFadesTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
-local timerCurseCD		= mod:NewVarTimer("v51.8-118.9", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
+local timerCurseCD		= mod:NewVarTimer("v51.8-115.6", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerAddsCD		= mod:NewAddsTimer(30, 29212, nil, "-Healer")
 
 mod:AddInfoFrameOption(29213, "RemoveCurse")
@@ -122,7 +122,7 @@ function mod:OnCombatStart()
 	self.vb.addsCount = 0
 	self.vb.curseCount = 0
 	timerAddsCD:Start(12)
-	timerCurseCD:Start("v6.4-26.8")
+	timerCurseCD:Start("v6.5-25.9")
 	timerTeleport:Start(90.8)
 	warnTeleportSoon:Schedule(70.8)
 	self:ScheduleMethod(90.8, "Balcony")

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -38,7 +38,7 @@ local specWarnAdds		= mod:NewSpecialWarningAdds(29212, "-Healer", nil, nil, 1, 2
 
 local timerTeleport		= mod:NewTimer(90, "TimerTeleport", "135736", nil, nil, 6)
 local timerTeleportBack	= mod:NewTimer(70, "TimerTeleportBack", "135736", nil, nil, 6)
-local timerCurse       	= mod:NewBuffActiveTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
+local timerCurse       	= mod:NewBuffFadesTimer(10, 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerCurseCD		= mod:NewVarTimer("v51.7-68", 29213, nil, "RemoveCurse", nil, 3, nil, DBM_COMMON_L.CURSE_ICON)
 local timerAddsCD		= mod:NewAddsTimer(30, 29212, nil, "-Healer")
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -45,17 +45,15 @@ local timerAddsCD		= mod:NewAddsTimer(30, 29252, nil, "-Healer", nil, 1, "136187
 
 mod:AddInfoFrameOption(29213, "RemoveCurse")
 
+local twipe = table.wipe
 local lines, sortedLines = {}, {}
 local curseTargets = {}
 local function updateInfoFrame()
-	table.wipe(lines)
-	table.wipe(sortedLines)
-
-	local i = 0
+	twipe(lines)
+	twipe(sortedLines)
 
 	for name in pairs(curseTargets) do
-		i = i + 1
-		sortedLines[i] = name
+		sortedLines[#sortedlines + 1] = name
 		lines[name] = ""
 	end
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -53,7 +53,7 @@ local function updateInfoFrame()
 	twipe(sortedLines)
 
 	for name in pairs(curseTargets) do
-		sortedLines[#sortedlines + 1] = name
+		sortedLines[#sortedLines + 1] = name
 		lines[name] = ""
 	end
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Noth.lua
@@ -194,7 +194,7 @@ function mod:OnSync(msg)
 		specWarnAdds:Play("killmob")
 		if self.vb.teleCount < 4 then
 			if self.vb.teleCount == 0 and self.vb.addsCount < 3 then--3 waves, 12, 34, 34
-				timerAddsCD:Start(34)--30 in Wrath
+				timerAddsCD:Start("v25.9-37.2)
 			elseif self.vb.teleCount == 1 then--3 waves, 3, 34, 30 (3 iffy)
 				if self.vb.addsCount == 1 then
 					timerAddsCD:Start(33.9)


### PR DESCRIPTION
This was a request from my guild leader

- Add a timer for the curse debuff
- Show the targets with curse in the info frame
- Names are removed from the frame as they get decursed
- When all names are removed from the list, hide the frame and cancel the curse timer
- The curse variation timer was not accounting for the fact that the time is paused while he is on balcony, therefore the variation shown was far larger than what is true
- Add special warning for curse of the plaguebringer