### PR TITLE
Update Sapphiron.lua

### DIFF
--- a/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
@@ -80,7 +80,7 @@ local function Landing()
 	if isMythic or DBM:IsSeasonal("SeasonOfDiscovery") then
 		warnAirPhaseSoon:Schedule(airPhaseTimer - 10)
 	else
-		if not mod.vb.airPhaseHPThreshold then 
+		if not mod.vb.airPhaseHPThreshold then
 			warnAirPhaseSoon:Schedule(50)
 		end
 	end

--- a/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
@@ -67,6 +67,7 @@ local berserkTimer		= mod:NewBerserkTimer(900)
 local noTargetTime = 0
 mod.vb.isFlying = false
 mod.vb.iceBlocks = 0
+mod.vb.airPhaseHPThreshold = false
 local UnitAffectingCombat = UnitAffectingCombat
 local isMythic = select(5, DBM:GetCurrentInstanceDifficulty()) == 4
 
@@ -77,12 +78,14 @@ end
 local function Landing()
 	mod.vb.iceBlocks = 0
 	if isMythic or DBM:IsSeasonal("SeasonOfDiscovery") then
-	warnAirPhaseSoon:Schedule(airPhaseTimer - 10)
+		warnAirPhaseSoon:Schedule(airPhaseTimer - 10)
 	else
-	warnAirPhaseSoon:Schedule(50)
+		warnAirPhaseSoon:Schedule(50)
 	end
 	warnLanded:Show()
-	timerAirPhase:Start(airPhaseTimer)
+	if not mod.vb.airPhaseHPThreshold then
+		timerAirPhase:Start(airPhaseTimer)
+	end
 	if DBM:IsSeasonal("SeasonOfDiscovery") then
 	mod:Schedule(airPhaseTimer + 1, timerBomb.Stop, timerBomb)
 	end
@@ -92,15 +95,16 @@ function mod:OnCombatStart()
 	noTargetTime = 0
 	self.vb.isFlying = false
 	self.vb.iceBlocks = 0
+	self.vb.airPhaseHPThreshold = false
 	self:RegisterShortTermEvents(
 		"UNIT_HEALTH"
 	)
 	-- TODO: confirm this, it seems to have changed with the Mythic hot fixes for both mythic and normal?
 	local initialAirPhaseTimer = isMythic and 39.66 or DBM:IsSeasonal("SeasonOfDiscovery") and 31 or "v31.2-45.9" -- Air phase timer is variable on Era
 	if isMythic or DBM:IsSeasonal("SeasonOfDiscovery") then
-	warnAirPhaseSoon:Schedule(initialAirPhaseTimer - 10)
+		warnAirPhaseSoon:Schedule(initialAirPhaseTimer - 10)
 	else
-	warnAirPhaseSoon:Schedule(30)
+		warnAirPhaseSoon:Schedule(30)
 	end
 	timerAirPhase:Start(initialAirPhaseTimer)
 	berserkTimer:Start(900)
@@ -198,6 +202,7 @@ end
 
 function mod:UNIT_HEALTH(uId)
 	if self:GetUnitCreatureId(uId) == 15989 and UnitHealth(uId) / UnitHealthMax(uId) <= 0.10 then
+		self.vb.airPhaseHPThreshold = true
 		self:SendSync("CancelAirPhaseTimer")
 		self:UnregisterShortTermEvents()
 	end

--- a/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
@@ -79,10 +79,8 @@ local function Landing()
 	mod.vb.iceBlocks = 0
 	if isMythic or DBM:IsSeasonal("SeasonOfDiscovery") then
 		warnAirPhaseSoon:Schedule(airPhaseTimer - 10)
-	else
-		if not mod.vb.airPhaseHPThreshold then
-			warnAirPhaseSoon:Schedule(50)
-		end
+	elseif not mod.vb.airPhaseHPThreshold then
+		warnAirPhaseSoon:Schedule(50)
 	end
 	warnLanded:Show()
 	if not mod.vb.airPhaseHPThreshold then

--- a/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
@@ -80,7 +80,9 @@ local function Landing()
 	if isMythic or DBM:IsSeasonal("SeasonOfDiscovery") then
 		warnAirPhaseSoon:Schedule(airPhaseTimer - 10)
 	else
-		warnAirPhaseSoon:Schedule(50)
+		if not mod.vb.airPhaseHPThreshold then 
+			warnAirPhaseSoon:Schedule(50)
+		end
 	end
 	warnLanded:Show()
 	if not mod.vb.airPhaseHPThreshold then

--- a/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
@@ -89,7 +89,7 @@ local function Landing()
 		timerAirPhase:Start(airPhaseTimer)
 	end
 	if DBM:IsSeasonal("SeasonOfDiscovery") then
-	mod:Schedule(airPhaseTimer + 1, timerBomb.Stop, timerBomb)
+		mod:Schedule(airPhaseTimer + 1, timerBomb.Stop, timerBomb)
 	end
 end
 

--- a/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/FrostwyrmLair/Sapphiron.lua
@@ -204,7 +204,6 @@ end
 
 function mod:UNIT_HEALTH(uId)
 	if self:GetUnitCreatureId(uId) == 15989 and UnitHealth(uId) / UnitHealthMax(uId) <= 0.10 then
-		self.vb.airPhaseHPThreshold = true
 		self:SendSync("CancelAirPhaseTimer")
 		self:UnregisterShortTermEvents()
 	end
@@ -213,6 +212,7 @@ end
 function mod:OnSync(msg)
 	if not self:IsInCombat() then return end
 	if msg == "CancelAirPhaseTimer" then
+		self.vb.airPhaseHPThreshold = true
 		warnAirPhaseSoon:Cancel()
 		timerAirPhase:Stop()
 	end


### PR DESCRIPTION
Summary

- The goal of this PR is to make it so that if Sapphiron reaches < 10% while in air phase, the air phase timer should not appear when he lands.